### PR TITLE
make sure latest build is distributed to targetted ccos

### DIFF
--- a/cliqr/getnewmayobuild.sls
+++ b/cliqr/getnewmayobuild.sls
@@ -1,0 +1,17 @@
+{% set mayotagversion = pillar['mayotagversion'] %}
+
+"Copy file from build server"
+  cmd.run:
+    - name: "scp root@osazureclient.mayo.edu:/root/cliqr_worker_{{ mayotagversion}}.tar /root/cliqr_worker_{{ mayotagversion }}.tar"
+
+"Load the tar file into a container"
+  cmd.run:
+    - name: "docker load -i /root/cliqr_worker_{{ mayotagversion}}.tar"
+
+"delete the tar file because it's big"
+  file.absent
+    - name: "/root/cliqr_worker_{{ mayotagversion}}.tar"
+
+"tag the new image as the latest"
+  cmd.run:
+    - name: "docker tag cliqr/worker:{{ mayotagversion }} cliqr/worker:latest"

--- a/process1.sls
+++ b/process1.sls
@@ -23,3 +23,13 @@
     - pillar:
         cliqrtagversion: {{ cliqrtagversion }}
         mayotagversion: {{ mayotagversion }}
+
+"Distribute latest build to ccos":
+  salt.state:
+    - tgt: 'cliqrccos'
+    - tgt_type: list
+    - ssh: True
+    - sls:
+      - cloud.cliqr.getnewmayobuild
+    - pillar:
+        mayotagversion: {{ mayotagversion }}


### PR DESCRIPTION
This is completely untested! Does this look like the right idea to push the file to a group of systems (cliqrccos) and issue some docker commands?

Can you remind me where I'd define which systems should be included in the cliqrccos target?

Thanks!